### PR TITLE
Remove zpios module

### DIFF
--- a/mkinitcpio-install/sd-zfs
+++ b/mkinitcpio-install/sd-zfs
@@ -8,7 +8,6 @@ build() {
 		zunicode \
 		zcommon \
 		zfs \
-		zpios \
 		spl
 
 	# udev rules


### PR DESCRIPTION
Since https://github.com/zfsonlinux/zfs/commit/c8f9061fc714696a53cf4d14a4567f0a83dbf862, the `zpios` module no longer exists, which leads to `mkinitcpio` errors.

Applying this might be problematic for those running a released ZFS, although I don't think the module is actually needed.