### PR TITLE
Make sd-zfs compatible with grub-mkconfig automatic ZFS detection.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -22,7 +22,7 @@ As snapshots are read-only and not bootable, they are automatically cloned to ne
 All subdatasets wil be checked for the same snapshot.
 
 Example:
-- Boot with root=tank/root@snap
+- Boot with root=ZFS=tank/root@snap
 - The following datasets with the following snapshots exist:
 ```
 tank/root
@@ -48,8 +48,8 @@ Users without Arch should read the manual installation instructions at the botto
 sd-zfs supports multiple kernel parameters to select what dataset to boot from and to tune the booting process.
 
 #### Which dataset to boot from
-- `root=zfs:somepool/somedataset` - Use this dataset to boot from
-- `root=zfs:AUTO` - Check all pools for the bootfs value. See rpool to narrow the search
+- `root=ZFS=somepool/somedataset` - Use this dataset to boot from
+- `root=ZFS=AUTO` - Check all pools for the bootfs value. See rpool to narrow the search
 - `rpool=somepool` - Check only this pool for the bootfs value. This may not contain slashes
 
 The root option can be suffixed with `@snap` to boot from a snapshot named `snap`.
@@ -132,7 +132,7 @@ This can be prevented via kernel parameter.
 
 ### Mounting
 The systemd unit `sysroot.mount` is overriden so it will run a custom command.
-This command figures out the bootfs (if `zfs:AUTO` is used) and handles snapshot creation.
+This command figures out the bootfs (if `ZFS=AUTO` is used) and handles snapshot creation.
 It proceeds to mount the correct dataset, including all subdatasets.
 
 ### Switching root

--- a/src/mount.initrd_zfs.c
+++ b/src/mount.initrd_zfs.c
@@ -13,9 +13,9 @@ int handleBootfs(char **pool) {
 	int ret = 1;
 
 	// Handle rpool
-	if (strncmp(*pool, "zfs:AUTO:", strlen("zfs:AUTO:")) == 0) {
-		rpool = malloc((strlen(*pool) - strlen("zfs:AUTO:") + 1) * sizeof(char));
-		strcpy(rpool, &((*pool)[strlen("zfs:AUTO:")]));
+	if (strncmp(*pool, "ZFS=AUTO:", strlen("ZFS=AUTO:")) == 0) {
+		rpool = malloc((strlen(*pool) - strlen("ZFS=AUTO:") + 1) * sizeof(char));
+		strcpy(rpool, &((*pool)[strlen("ZFS=AUTO:")]));
 	}
 
 	ret = zfs_get_bootfs(rpool, pool);
@@ -115,7 +115,7 @@ int main(int argc, char *argv[]) {
 	snap = strtok(NULL, "@");
 
 	// Check if we need to handle bootfs
-	if (strncmp(dataset, "zfs:AUTO", strlen("zfs:AUTO")) == 0) {
+	if (strncmp(dataset, "ZFS=AUTO", strlen("ZFS=AUTO")) == 0) {
 		if (handleBootfs(&dataset) != 0) {
 			fprintf(stderr, "Can not get bootfs value\n");
 			free(dataset);

--- a/src/zfs-generator.c
+++ b/src/zfs-generator.c
@@ -280,11 +280,11 @@ int generateSysrootUnit(char *directory, int bootfs, char *dataset, char *snapsh
 	// Discover bootfs
 	if (bootfs == 1) {
 		if (dataset == NULL) {
-			what = malloc((strlen("zfs:AUTO") + 1) * sizeof(char));
-			strcpy(what, "zfs:AUTO");
+			what = malloc((strlen("ZFS=AUTO") + 1) * sizeof(char));
+			strcpy(what, "ZFS=AUTO");
 		} else {
-			what = malloc((strlen("zfs:AUTO:") + strlen(dataset) + 1) * sizeof(char));
-			strcpy(what, "zfs:AUTO:");
+			what = malloc((strlen("ZFS=AUTO:") + strlen(dataset) + 1) * sizeof(char));
+			strcpy(what, "ZFS=AUTO:");
 			strcat(what, dataset);
 		}
 	} else {
@@ -360,7 +360,7 @@ int main(int argc, char *argv[]) {
 		exit(1);
 	}
 	// Handle non-ZFS values
-	if (strncmp(root, "zfs:", strlen("zfs:")) != 0) {
+	if (strncmp(root, "ZFS=", strlen("ZFS=")) != 0) {
 		printf("root= does not point to anything ZFS-related. Quitting\n");
 		exit(0);
 	}
@@ -376,7 +376,7 @@ int main(int argc, char *argv[]) {
 		exit(1);
 	}
 	// Generate units
-	if (strcmp(root, "zfs:AUTO") != 0 && strncmp(root, "zfs:AUTO@", strlen("zfs:AUTO@")) != 0) {
+	if (strcmp(root, "ZFS=AUTO") != 0 && strncmp(root, "ZFS=AUTO@", strlen("ZFS=AUTO@")) != 0) {
 		poolName = malloc((strlen(root) - 4 + 1) * sizeof(char));
 		strcpy(poolName, &(root[4]));
 
@@ -410,9 +410,9 @@ int main(int argc, char *argv[]) {
 	strtok(root, "@");
 	snap = strtok(NULL, "@");
 	// Direct dataset
-	if (strcmp(root, "zfs:AUTO") != 0) {
-		dataset = malloc((strlen(root) - strlen("zfs:") + 1) * sizeof(char));
-		strcpy(dataset, &(root[strlen("zfs:")]));
+	if (strcmp(root, "ZFS=AUTO") != 0) {
+		dataset = malloc((strlen(root) - strlen("ZFS=") + 1) * sizeof(char));
+		strcpy(dataset, &(root[strlen("ZFS=")]));
 		free(root);
 
 		if (generateSysrootUnit(argv[systemd_param], 0, dataset, snap) != 0) {


### PR DESCRIPTION
Modern grub-mkconfig auto-detects ZFS filesystems, and correctly sets root= cmdline in grub.cfg.  However, it uses the "ZFS=" prefix, instead of the "zfs:" prefix traditionally used by sd-zfs.  This change will make sd-zfs easier to use by eliminating the need for users to edit cmdlines, as they can rely on vanilla grub-mkconfig behavior to set the right root= by default.